### PR TITLE
Fix #13

### DIFF
--- a/scrapper/scrapper/pipelines.py
+++ b/scrapper/scrapper/pipelines.py
@@ -115,7 +115,7 @@ class SchedulePipeline(MySQLPipeline):
     def process_item(self, item, spider):
         if not isinstance(item, items.Schedule):
             return item
-        sql = "INSERT IGNORE INTO `{0}` (`{1}`) VALUES ({2})"
+        sql = "INSERT INTO `{0}` (`{1}`) VALUES ({2})"
         columns = "`, `".join(item.keys())
         values = ", ".join("%s" for _ in item.values())
         prepared = sql.format('schedule', columns, values)

--- a/scrapper/scrapper/spiders/schedule_spider.py
+++ b/scrapper/scrapper/spiders/schedule_spider.py
@@ -66,7 +66,7 @@ class ScheduleSpider(scrapy.Spider):
     def classUnitRequests(self):
         con_info = ConInfo()
         with con_info.connection.cursor() as cursor:
-            sql = "SELECT `id`, `schedule_url` FROM `course_unit` WHERE schedule_url IS NOT NULL AND course_id = 209"
+            sql = "SELECT `id`, `schedule_url` FROM `course_unit` WHERE schedule_url IS NOT NULL"
             cursor.execute(sql)
             self.class_units = cursor.fetchall()
 


### PR DESCRIPTION
Fixes #13 by adding dont_filter to the Scrapy requests.
This fix comes with an increased scraping time due to pages being revisited (specifically composed class pages). Future improvements could be done by caching/storing the classes that make up each composed class.