### PR TITLE
Fix login mechanism using mobile API endpoint

### DIFF
--- a/scrapper/scrapper/spiders/course_unit_spider.py
+++ b/scrapper/scrapper/spiders/course_unit_spider.py
@@ -3,6 +3,7 @@ import scrapy
 from scrapy.http import Request, FormRequest
 from urllib.parse import urlparse, parse_qs, urlencode
 from datetime import datetime
+import json
 
 from ..con_info import ConInfo
 from ..items import CourseUnit
@@ -38,12 +39,18 @@ class CourseUnitSpider(scrapy.Spider):
         """
 
         if response.status == 200:
-            self.log("Successfully logged in. Let's start crawling!")
-            # Spider will now call the parse method with a request
-            return self.courseRequests()
+            response_body = json.loads(response.body)
+            if response_body['authenticated']:
+                self.log("Successfully logged in. Let's start crawling!")
+                return self.courseRequests()
+            else:
+                message = 'Login failed. SIGARRA\'s response: error type "{}";\nerror message "{}"'.format(
+                    response_body.erro, response_body.erro_msg)
+                print(message, flush=True)
+                self.log(message)
         else:
-            print('Login failed. Please try again.')
-            self.log('Login failed. Please try again.')
+            print('Login Failed. HTTP Error {}'.format(response.status), flush=True)
+            self.log('Login Failed. HTTP Error {}'.format(response.status))
 
     def courseRequests(self):
         print("Gathering courses")

--- a/scrapper/scrapper/spiders/course_unit_spider.py
+++ b/scrapper/scrapper/spiders/course_unit_spider.py
@@ -11,7 +11,7 @@ from ..items import CourseUnit
 class CourseUnitSpider(scrapy.Spider):
     name = "course_units"
     allowed_domains = ['sigarra.up.pt']
-    login_page_spider = 'https://sigarra.up.pt/feup/pt/mob_val_geral.autentica'
+    login_page_base = 'https://sigarra.up.pt/feup/pt/mob_val_geral.autentica'
     password = None
 
     def __init__(self, category=None, *args, **kwargs):

--- a/scrapper/scrapper/spiders/course_unit_spider.py
+++ b/scrapper/scrapper/spiders/course_unit_spider.py
@@ -1,7 +1,7 @@
 import getpass
 import scrapy
 from scrapy.http import Request, FormRequest
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, urlencode
 from datetime import datetime
 
 from ..con_info import ConInfo
@@ -11,60 +11,42 @@ from ..items import CourseUnit
 class CourseUnitSpider(scrapy.Spider):
     name = "course_units"
     allowed_domains = ['sigarra.up.pt']
-    login_page = 'https://sigarra.up.pt/'
+    login_page_spider = 'https://sigarra.up.pt/feup/pt/mob_val_geral.autentica'
     password = None
 
     def __init__(self, category=None, *args, **kwargs):
         super(CourseUnitSpider, self).__init__(*args, **kwargs)
 
+    def format_login_url(self):
+        return '{}?{}'.format(self.login_page_base, urlencode({
+            'pv_login': self.user,
+            'pv_password': self.password
+        }))
+
     def start_requests(self):
         """This function is called before crawling starts."""
-        yield Request(url=self.login_page, callback=self.login)
-
-    def login(self, response):
-        """Generate a login request. The login form needs the following parameters:
-            p_app : 162 -> This is always 162
-            p_amo : 55 -> This is always 55
-            p_address : WEB_PAGE.INICIAL -> This is always 'WEB_PAGE.INICIAL'
-            p_user : username -> This is the username used to login
-            p_pass : password -> This is the password used to login
-        """
 
         if self.password is None:
             self.password = getpass.getpass(prompt='Password: ', stream=None)
 
-        yield FormRequest.from_response(response,
-                                        formdata={
-                                            'p_app': '162', 'p_amo': '55',
-                                            'p_address': 'WEB_PAGE.INICIAL',
-                                            'p_user': self.user,
-                                            'p_pass': self.password},
-                                        callback=self.check_login_response)
+        yield Request(url=self.format_login_url(), callback=self.check_login_response)
 
     def check_login_response(self, response):
         """Check the response returned by a login request to see if we are
-        successfully logged in. It is done by checking if a button's value is
-        'Terminar sessão', that translates to 'Sign out', meaning the login was successful.
-        It also verifies if the login failed due to incorrect credentials, in case the button's
-        value equals 'Iniciar sessão', that translates to 'Sign in',
-        meaning the credentials were wrong or due to a change in website structure.
+        successfully logged in. Since we used the mobile login API endpoint,
+        we can just check the status code.
         """
-        result = response.xpath(
-            '//div[@id="caixa-validacao-conteudo"]/button[@type="submit"]/@value').extract_first()
 
-        if result == "Terminar sessão":
+        if response.status == 200:
             self.log("Successfully logged in. Let's start crawling!")
             # Spider will now call the parse method with a request
             return self.courseRequests()
-        elif result == "Iniciar sessão":
+        else:
             print('Login failed. Please try again.')
             self.log('Login failed. Please try again.')
-        else:
-            print('Unexpected result. Website structure may have changed.')
-            self.log('Unexpected result. Website structure may have changed.')
 
     def courseRequests(self):
-        self.log("Gathering courses")
+        print("Gathering courses")
         con_info = ConInfo()
         with con_info.connection.cursor() as cursor:
             sql = "SELECT course.id, year, course.course_id, faculty.acronym FROM course JOIN faculty ON course.faculty_id = faculty.id"
@@ -82,8 +64,10 @@ class CourseUnitSpider(scrapy.Spider):
                 callback=self.extractSearchPages)
 
     def extractSearchPages(self, response):
-        last_page_url = response.css(".paginar-saltar-barra-posicao > div:last-child > a::attr(href)").extract_first()
-        last_page = int(parse_qs(urlparse(last_page_url).query)['pv_num_pag'][0]) if last_page_url is not None else 1
+        last_page_url = response.css(
+            ".paginar-saltar-barra-posicao > div:last-child > a::attr(href)").extract_first()
+        last_page = int(parse_qs(urlparse(last_page_url).query)[
+            'pv_num_pag'][0]) if last_page_url is not None else 1
         for x in range(1, last_page + 1):
             yield scrapy.http.Request(
                 url=response.url + "&pv_num_pag={}".format(x),
@@ -94,36 +78,42 @@ class CourseUnitSpider(scrapy.Spider):
         course_units_table = response.css("table.dados .d")
         for course_unit_row in course_units_table:
             yield scrapy.http.Request(
-                url=response.urljoin(course_unit_row.css(".t > a::attr(href)").extract_first()),
+                url=response.urljoin(course_unit_row.css(
+                    ".t > a::attr(href)").extract_first()),
                 meta=response.meta,
                 callback=self.extractCourseUnitInfo)
 
     def extractCourseUnitInfo(self, response):
-        name = response.xpath('//div[@id="conteudoinner"]/h1[2]/text()').extract_first().strip()
+        name = response.xpath(
+            '//div[@id="conteudoinner"]/h1[2]/text()').extract_first().strip()
 
-        # Checks if the course unit page is valid. 
+        # Checks if the course unit page is valid.
         # If name == 'Sem Resultados', then it is not.
         if name == 'Sem Resultados':
-            return None # Return None as yielding would continue the program and crash at the next assert
+            return None  # Return None as yielding would continue the program and crash at the next assert
 
-        course_unit_id = parse_qs(urlparse(response.url).query)['pv_ocorrencia_id'][0]
-        acronym = response.xpath('//div[@id="conteudoinner"]/table[@class="formulario"][1]//td[text()="Sigla:"]/following-sibling::td[1]/text()').extract_first()
+        course_unit_id = parse_qs(urlparse(response.url).query)[
+            'pv_ocorrencia_id'][0]
+        acronym = response.xpath(
+            '//div[@id="conteudoinner"]/table[@class="formulario"][1]//td[text()="Sigla:"]/following-sibling::td[1]/text()').extract_first()
 
         url = response.url
-        schedule_url = response.xpath('//a[text()="Horário"]/@href').extract_first()
+        schedule_url = response.xpath(
+            '//a[text()="Horário"]/@href').extract_first()
 
         # If there is no schedule for this course unit
         if schedule_url is not None:
             schedule_url = response.urljoin(schedule_url)
 
-        course_year = int(response.xpath('//div[@id="conteudoinner"]/table[@class="dados"]//td[@class="l"]/text()').extract_first())
+        course_year = int(response.xpath(
+            '//div[@id="conteudoinner"]/table[@class="dados"]//td[@class="l"]/text()').extract_first())
 
         assert course_year > 0 and course_year < 10
 
         # Occurrence has a string that contains both the year and the semester type
         occurrence = response.css('#conteudoinner > h2::text').extract_first()
 
-        ## Possible types: '1', '2', 'A', 'SP'
+        # Possible types: '1', '2', 'A', 'SP'
         # '1' and '2' represent a semester
         # 'A' represents an annual course unit
         # 'SP' represents a course unit without effect this year
@@ -150,14 +140,14 @@ class CourseUnitSpider(scrapy.Spider):
 
         for semester in semesters:
             yield CourseUnit(
-              course_unit_id=course_unit_id,
-              course_id=response.meta['course_id'],
-              name=name,
-              acronym=acronym,
-              url=url,
-              course_year=course_year,
-              schedule_url=schedule_url,
-              year=year,
-              semester=semester,
-              last_updated=datetime.now()
-        )
+                course_unit_id=course_unit_id,
+                course_id=response.meta['course_id'],
+                name=name,
+                acronym=acronym,
+                url=url,
+                course_year=course_year,
+                schedule_url=schedule_url,
+                year=year,
+                semester=semester,
+                last_updated=datetime.now()
+            )

--- a/scrapper/scrapper/spiders/schedule_spider.py
+++ b/scrapper/scrapper/spiders/schedule_spider.py
@@ -3,6 +3,7 @@ import scrapy
 from datetime import datetime
 from scrapy.http import Request, FormRequest
 import urllib.parse
+import json
 
 from ..con_info import ConInfo
 from ..items import Schedule
@@ -40,12 +41,18 @@ class ScheduleSpider(scrapy.Spider):
         """
 
         if response.status == 200:
-            self.log("Successfully logged in. Let's start crawling!")
-            # Spider will now call the parse method with a request
-            return self.classUnitRequests()
+            response_body = json.loads(response.body)
+            if response_body['authenticated']:
+                self.log("Successfully logged in. Let's start crawling!")
+                return self.classUnitRequests()
+            else:
+                message = 'Login failed. SIGARRA\'s response: error type "{}";\nerror message "{}"'.format(
+                    response_body.erro, response_body.erro_msg)
+                print(message, flush=True)
+                self.log(message)
         else:
-            print('Login failed. Please try again.')
-            self.log('Login failed. Please try again.')
+            print('Login Failed. HTTP Error {}'.format(response.status), flush=True)
+            self.log('Login Failed. HTTP Error {}'.format(response.status))
 
     def classUnitRequests(self):
         con_info = ConInfo()


### PR DESCRIPTION
When logging into SIGARRA to scrape course units and schedules, we were going to the main page and logging in using the form.

However, that page now features a hidden redirect that stopped our spiders from correctly checking that we signed in.

To mitigate this, we now log in via an endpoint in the mobile API.